### PR TITLE
zengakuフォームの送信処理を追加

### DIFF
--- a/frontend/src/app/check/_actions/zengaku.ts
+++ b/frontend/src/app/check/_actions/zengaku.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { parseWithZod } from "@conform-to/zod";
+import { redirect } from "next/navigation";
+import { zengakuSchema } from "../_schemas/zengaku";
+
+export async function submitZengakuForm(
+	_prevState: unknown,
+	formData: FormData,
+) {
+	const submission = parseWithZod(formData, {
+		schema: zengakuSchema,
+	});
+
+	if (submission.status !== "success") {
+		return submission.reply();
+	}
+
+	// 成功時（後でlocalStorage保存処理を追加予定）
+	console.log("フォームデータ：", submission.value);
+
+	//結果ページにリダイレクト
+	redirect("/check/zengaku/result");
+}


### PR DESCRIPTION
## 概要
全学教育科目の単位入力フォーム用のServer Actionを実装しました。

## 変更内容
- `app/check/_actions/zengaku.ts` を新規作成
- Conform + Zod を使用したフォームバリデーション処理
- バリデーション成功時は結果ページへリダイレクト
- バリデーション失敗時はエラー情報をフォームに返却

## 技術詳細
- `parseWithZod` でzengakuSchemaに基づくバリデーション
- Server Actions (`'use server'`) を使用
- バリデーション成功時は `/check/zengaku/result` にリダイレクト

## 今後の予定
- localStorage保存処理の追加
- フォームUIページの実装
