### PR TITLE
gh-56 implement course credits input form

### DIFF
--- a/frontend/src/app/check/_schemas/gakubu.ts
+++ b/frontend/src/app/check/_schemas/gakubu.ts
@@ -13,11 +13,9 @@ export const gakubuSchema = z.object({
 	coreSpecialized: z.number().int().min(0, errorMessage),
 
 	// 専門応用科目Ⅱ
-	appliedSpecialized2: z.object({
-		majorField: z.number().int().min(0, errorMessage),
-		minorField: z.number().int().min(0, errorMessage),
-		otherFields: z.number().int().min(0, errorMessage),
-	}),
+	appliedSpecialized2MajorField: z.number().int().min(0, errorMessage),
+	appliedSpecialized2MinorField: z.number().int().min(0, errorMessage),
+	appliedSpecialized2OtherFields: z.number().int().min(0, errorMessage),
 
 	// 学部教育科目その他
 	departmentEducationOthers: z.number().int().min(0, errorMessage),

--- a/frontend/src/app/check/gakubu/page.tsx
+++ b/frontend/src/app/check/gakubu/page.tsx
@@ -1,12 +1,84 @@
+"use client";
+
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod";
+import { useActionState } from "react";
 import { PageHeader } from "@/components/common/PageHeader";
+import { submitGakubForm } from "../_actions/gakubu";
+import { FormSection } from "../_components/FormSection";
+import { NumberField } from "../_components/NumberField";
+import { gakubuSchema } from "../_schemas/gakubu";
 
 export default function GakubuPage() {
+	const [lastResult, action] = useActionState(submitGakubForm, undefined);
+
+	const [form, fields] = useForm({
+		lastResult,
+		onValidate({ formData }) {
+			return parseWithZod(formData, { schema: gakubuSchema });
+		},
+		onSubmit(_, { formData }) {
+			const submission = parseWithZod(formData, { schema: gakubuSchema });
+			if (submission.status === "success") {
+				try {
+					localStorage.setItem(
+						"gakubu-credits",
+						JSON.stringify(submission.value),
+					);
+				} catch (error) {
+					console.error("localStorage保存に失敗:", error);
+				}
+			}
+		},
+		shouldValidate: "onBlur",
+		shouldRevalidate: "onInput",
+	});
+
 	return (
 		<div className="min-h-screen p-8 space-y-8">
 			<PageHeader
 				title="履修単位（学部教育科目）"
 				subtitle="取得済みの単位を入力してください。"
 			/>
+			<form
+				id={form.id}
+				onSubmit={form.onSubmit}
+				action={action}
+				noValidate
+				className="space-y-6"
+			>
+				<FormSection title="基本科目">
+					<NumberField field={fields.basicSpecialized} label="専門基礎" />
+					<NumberField field={fields.basicSeminar} label="基礎演習" />
+					<NumberField field={fields.coreSpecialized} label="専門基幹" />
+				</FormSection>
+				<FormSection title="専門応用科目Ⅱ">
+					<NumberField
+						field={fields.appliedSpecialized2MajorField}
+						label="主専攻分野"
+					/>
+					<NumberField
+						field={fields.appliedSpecialized2MinorField}
+						label="副専攻分野"
+					/>
+					<NumberField
+						field={fields.appliedSpecialized2OtherFields}
+						label="その他分野"
+					/>
+				</FormSection>
+				<FormSection title="その他">
+					<NumberField
+						field={fields.departmentEducationOthers}
+						label="特殊講義・経営科目等"
+					/>
+				</FormSection>
+				<button
+					type="submit"
+					className="w-full bg-brand text-white py-2 px-4 rounded-md hover:bg-brand-sec focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+				>
+					次へ
+				</button>
+			</form>
 		</div>
 	);
 }

--- a/frontend/src/app/check/gakubu/result/page.tsx
+++ b/frontend/src/app/check/gakubu/result/page.tsx
@@ -1,0 +1,3 @@
+export default function GakubResultPage() {
+	return <div>hogehoge</div>;
+}

--- a/frontend/src/app/check/zengaku/page.tsx
+++ b/frontend/src/app/check/zengaku/page.tsx
@@ -27,7 +27,6 @@ export default function ZengakuPage() {
 					);
 				} catch (error) {
 					console.error("localStorage保存に失敗:", error);
-					// ユーザーに通知（後述）
 				}
 			}
 		},


### PR DESCRIPTION
## 概要

学部教育科目の履修単位入力フォームを新規実装しました。
ユーザーが取得済み単位を入力し、ローカルに保存したうえで次の処理に進めるようになります。

## 主な変更点

* **`GakubuPage` コンポーネントを追加**

  * `PageHeader` を利用したタイトル／サブタイトル表示
  * `FormSection` で科目区分ごとにセクション化
  * `NumberField` による単位数入力フィールドを実装
* **入力項目**

  * 基本科目：専門基礎、基礎演習、専門基幹
  * 専門応用科目Ⅱ：主専攻分野、副専攻分野、その他分野
  * その他：特殊講義・経営科目等
* **バリデーション**

  * `@conform-to/react` と `@conform-to/zod` を利用
  * `gakubuSchema` に基づく入力チェック
* **データ保存**

  * `localStorage` に `gakubu-credits` として保存
  * 保存失敗時は `console.error` を出力
* **UI**

  * Tailwind CSS による基本的なスタイル付け
  * 「次へ」ボタンを配置

## 動作確認

* 各入力フィールドに数値を入力後、「次へ」を押下すると `localStorage` に値が保存されることを確認
* 入力不備がある場合は `zod` に基づいてバリデーションが実行されることを確認



<img width="958" height="1084" alt="image" src="https://github.com/user-attachments/assets/0999bde1-58cc-4f73-be32-7ab133defc6d" />


validationチェック
<img width="954" height="568" alt="image" src="https://github.com/user-attachments/assets/45f0c350-f76e-49af-8610-7d18f8251348" />
